### PR TITLE
Fetch missions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "react-router-dom": "^6.15.0",
         "react-scripts": "5.0.1",
         "redux-logger": "^3.0.6",
+        "redux-thunk": "^2.4.2",
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
@@ -20691,16 +20692,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=4.2.0"
       }
     },
     "node_modules/unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "react-router-dom": "^6.15.0",
     "react-scripts": "5.0.1",
     "redux-logger": "^3.0.6",
+    "redux-thunk": "^2.4.2",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/src/components/Missions.js
+++ b/src/components/Missions.js
@@ -1,11 +1,36 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { fetchMissions } from '../redux/missions/missionsSlice';
 
 function Missions() {
-  return (
-    <div>
-      Missions
-    </div>
-  );
+  const dispatch = useDispatch();
+  const missions = useSelector((state) => state.missions.missions);
+  const status = useSelector((state) => state.missions.status);
+
+  useEffect(() => {
+    if (status === 'idle') {
+      dispatch(fetchMissions());
+    }
+  }, [status, dispatch]);
+
+  if (status === 'loading') {
+    return <div>Loading...</div>;
+  } if (status === 'succeeded') {
+    return (
+      <div>
+        {missions.map((mission) => (
+          <div key={mission.mission_id}>
+            <h2>{mission.mission_name}</h2>
+            <p>{mission.description}</p>
+          </div>
+        ))}
+      </div>
+    );
+  } if (status === 'failed') {
+    return <div>Error loading missions.</div>;
+  }
+
+  return null;
 }
 
 export default Missions;

--- a/src/index.js
+++ b/src/index.js
@@ -1,19 +1,21 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
+import { Provider } from 'react-redux';
 import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
+import store from './redux/store';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
-  <BrowserRouter>
-    <React.StrictMode>
-      <App />
-    </React.StrictMode>
-    ,
-  </BrowserRouter>,
-
+  <Provider store={store}>
+    <BrowserRouter>
+      <React.StrictMode>
+        <App />
+      </React.StrictMode>
+    </BrowserRouter>
+  </Provider>,
 );
 
 reportWebVitals();

--- a/src/redux/missions/missionsSlice.js
+++ b/src/redux/missions/missionsSlice.js
@@ -1,13 +1,43 @@
-import { createSlice } from '@reduxjs/toolkit';
+import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
+
+// Asynchronous action to fetch missions
+export const fetchMissions = createAsyncThunk(
+  'missions/fetchMissions',
+  async () => {
+    const response = await fetch('https://api.spacexdata.com/v3/missions');
+    const data = await response.json();
+    return data.map((mission) => ({
+      mission_id: mission.mission_id,
+      mission_name: mission.mission_name,
+      description: mission.description,
+    }));
+  },
+);
 
 const initialState = {
   missions: [],
+  status: 'idle', // idle, loading, succeeded, failed
+  error: null,
 };
 
 const missionsSlice = createSlice({
   name: 'missions',
   initialState,
   reducers: {},
+  extraReducers: (builder) => {
+    builder
+      .addCase(fetchMissions.pending, (state) => {
+        state.status = 'loading';
+      })
+      .addCase(fetchMissions.fulfilled, (state, action) => {
+        state.status = 'succeeded';
+        state.missions = action.payload;
+      })
+      .addCase(fetchMissions.rejected, (state, action) => {
+        state.status = 'failed';
+        state.error = action.error.message;
+      });
+  },
 });
 
-export default missionsSlice.reducers;
+export default missionsSlice.reducer;

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -7,6 +7,7 @@ const store = configureStore({
     missions: missionsReducer,
     rockets: rocketReducer,
   },
+  middleware: (getDefaultMiddleware) => getDefaultMiddleware(),
 });
 
 export default store;


### PR DESCRIPTION
## Fetch Missions Data from API

- Fetch data from the Missions endpoint (https://api.spacexdata.com/v3/missions) when a user navigates to the Missions section.
- Once the data are fetched, dispatch an action to store the selected data in Redux store:
mission_id
mission_name
description
- Only dispatched those actions once and did not add data to store on every re-render (i.e. when changing views / using navigation).